### PR TITLE
Add aria labels for screen readers and title attr for tool tips

### DIFF
--- a/cypress/integration/blockquote_spec.js
+++ b/cypress/integration/blockquote_spec.js
@@ -25,4 +25,8 @@ describe('Blockquote', () => {
     cy.get('#editor').type('I like quoted text');
     cy.get('#editor blockquote').should('have.text', 'I like quoted text');
   });
+
+  it('should have aria label', () => {
+    cy.get('button[data-item="blockquote"]').should('have.attr', 'aria-label', 'Toggle block quote');
+  });
 });

--- a/cypress/integration/bullet_list_spec.js
+++ b/cypress/integration/bullet_list_spec.js
@@ -23,4 +23,8 @@ describe('Bullet list', () => {
     cy.get('#editor ul').should('have.length', 1);
     cy.get('#editor li').should('have.length', 1);
   });
+
+  it('should have aria label', () => {
+    cy.get('button[data-item="bullet_list"]').should('have.attr', 'aria-label', 'Toggle bullet list');
+  });
 });

--- a/cypress/integration/code_block_spec.js
+++ b/cypress/integration/code_block_spec.js
@@ -62,4 +62,8 @@ describe('Code block', () => {
       '~~~javascript\nvar name = "code";\n~~~\n\n~~~python\ndef name:\n    code\n~~~'
     );
   });
+
+  it('should have aria label', () => {
+    cy.get('button[data-item="code_block"]').should('have.attr', 'aria-label', 'Toggle code block');
+  });
 });

--- a/cypress/integration/emphasis_spec.js
+++ b/cypress/integration/emphasis_spec.js
@@ -26,4 +26,8 @@ describe('Emphasis', () => {
     cy.get('#editor').type('I like italic text');
     cy.get('#editor em').should('have.text', 'I like italic text');
   });
+
+  it('should have aria label', () => {
+    cy.get('button[data-item="em"]').should('have.attr', 'aria-label', 'Toggle emphasis');
+  });
 });

--- a/cypress/integration/heading_spec.js
+++ b/cypress/integration/heading_spec.js
@@ -29,4 +29,8 @@ describe('Heading', () => {
     cy.get('#editor').type('I like heading text');
     cy.get('#editor h1').should('have.text', 'I like heading text');
   });
+
+  it('should have aria label', () => {
+    cy.get('button[data-item="heading"]').should('have.attr', 'aria-label', 'Toggle heading');
+  });
 });

--- a/cypress/integration/image_spec.js
+++ b/cypress/integration/image_spec.js
@@ -75,4 +75,8 @@ describe('Image', () => {
       cy.get('#editor placeholder').should('not.exist');
     });
   });
+
+  it('should have aria label', () => {
+    cy.get('button[data-item="image"]').should('have.attr', 'aria-label', 'Upload image');
+  });
 });

--- a/cypress/integration/inline_code_spec.js
+++ b/cypress/integration/inline_code_spec.js
@@ -22,4 +22,8 @@ describe('Inline code', () => {
     cy.get('#editor').type('I like code text');
     cy.get('#editor code').should('have.text', 'I like code text');
   });
+
+  it('should have aria label', () => {
+    cy.get('button[data-item="code"]').should('have.attr', 'aria-label', 'Toggle code');
+  });
 });

--- a/cypress/integration/ordered_list_spec.js
+++ b/cypress/integration/ordered_list_spec.js
@@ -23,4 +23,8 @@ describe('Ordered list', () => {
     cy.get('#editor ol').should('have.length', 1);
     cy.get('#editor li').should('have.length', 1);
   });
+
+  it('should have aria label', () => {
+    cy.get('button[data-item="ordered_list"]').should('have.attr', 'aria-label', 'Toggle ordered list');
+  });
 });

--- a/cypress/integration/strong_spec.js
+++ b/cypress/integration/strong_spec.js
@@ -12,7 +12,7 @@ describe('Strong', () => {
         .type('I like strong text');
       cy.get('#editor strong').should('have.text', 'I like strong text');
       cy.get('input[type="hidden"]').should('have.value', '**I like strong text**');
-    });  
+    });
   })
 
   it('supports strong markdown keyboard shortcut', () => {
@@ -31,5 +31,9 @@ describe('Strong', () => {
     cy.get('#editor').type('I like strong text');
     cy.get('#editor strong').should('have.text', 'I like strong text');
     cy.get('input[type="hidden"]').should('have.value', '**I like strong text**');
+  });
+
+  it('should have aria label', () => {
+    cy.get('button[data-item="strong"]').should('have.attr', 'aria-label', 'Toggle bold');
   });
 });

--- a/src/Editor/BaseType.ts
+++ b/src/Editor/BaseType.ts
@@ -12,6 +12,10 @@ class BaseType {
     return '';
   }
 
+  get label() {
+    return '';
+  }
+
   get icon() {
     return '';
   }
@@ -55,6 +59,7 @@ class BaseType {
         icon: this.icon,
         command: this.command,
         type: this.type,
+        label: this.label,
       };
     }
 

--- a/src/Editor/Marks/Emphasis.ts
+++ b/src/Editor/Marks/Emphasis.ts
@@ -7,6 +7,10 @@ class Emphasis extends Mark {
     return 'em';
   }
 
+  get label() {
+    return 'Toggle emphasis';
+  }
+
   get icon() {
     return 'Italic';
   }

--- a/src/Editor/Marks/InlineCode.ts
+++ b/src/Editor/Marks/InlineCode.ts
@@ -7,6 +7,10 @@ class InlineCode extends Mark {
     return 'code';
   }
 
+  get label() {
+    return 'Toggle code';
+  }
+
   get icon() {
     return 'Code';
   }

--- a/src/Editor/Marks/Strong.ts
+++ b/src/Editor/Marks/Strong.ts
@@ -7,6 +7,10 @@ class Strong extends Mark {
     return 'strong';
   }
 
+  get label() {
+    return 'Toggle bold';
+  }
+
   get icon() {
     return 'Bold';
   }

--- a/src/Editor/Nodes/Blockquote.ts
+++ b/src/Editor/Nodes/Blockquote.ts
@@ -7,6 +7,10 @@ class Blockquote extends Node {
     return 'blockquote';
   }
 
+  get label() {
+    return 'Toggle block quote';
+  }
+
   get icon() {
     return 'Quote';
   }

--- a/src/Editor/Nodes/BulletList.ts
+++ b/src/Editor/Nodes/BulletList.ts
@@ -7,6 +7,10 @@ class BulletList extends Node {
     return 'bullet_list';
   }
 
+  get label() {
+    return 'Toggle bullet list';
+  }
+
   get icon() {
     return 'UnorderedList';
   }

--- a/src/Editor/Nodes/CodeBlock.ts
+++ b/src/Editor/Nodes/CodeBlock.ts
@@ -7,6 +7,10 @@ class CodeBlock extends Node {
     return 'code_block';
   }
 
+  get label() {
+    return 'Toggle code block';
+  }
+
   get icon() {
     return 'CodeBlock';
   }

--- a/src/Editor/Nodes/Heading.ts
+++ b/src/Editor/Nodes/Heading.ts
@@ -9,6 +9,10 @@ class Heading extends Node {
     return 'heading';
   }
 
+  get label() {
+    return 'Toggle heading';
+  }
+
   get icon() {
     return 'Heading';
   }

--- a/src/Editor/Nodes/OrderedList.ts
+++ b/src/Editor/Nodes/OrderedList.ts
@@ -7,6 +7,10 @@ class OrderedList extends Node {
     return 'ordered_list';
   }
 
+  get label() {
+    return 'Toggle ordered list';
+  }
+
   get icon() {
     return 'OrderedList';
   }

--- a/src/Toolbar/ImageUpload.tsx
+++ b/src/Toolbar/ImageUpload.tsx
@@ -38,7 +38,12 @@ const ImageUpload = ({
         accept=".jpg,.jpeg,.png,.gif"
         onChange={onImageUpload}
       />
-      <button data-item="image" className="item fileUploadWrapper--button">
+      <button
+        data-item="image"
+        className="item fileUploadWrapper--button"
+        aria-label="Upload image"
+        title="Upload image"
+      >
         <Icons.Image />
       </button>
     </div>

--- a/src/Toolbar/Item.tsx
+++ b/src/Toolbar/Item.tsx
@@ -16,6 +16,8 @@ const Item: FunctionComponent<ToolbarItem> = ({
       data-item={name}
       onClick={() => onClick(item)}
       type="button"
+      aria-label={item.label}
+      title={item.label}
     >
       <Icon />
     </button>

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export type MarkDownEditor = {
 export type MenuItem = {
   name: string;
   icon: string;
+  label: string;
   command: (
     state: EditorState,
     dispatch: EditorView['dispatch'],


### PR DESCRIPTION
Previously the screen reader called all buttons "button" which is rather confusing. Now it names them all what they are
The user can hover a button too to find out what it does

[Trello card](https://trello.com/c/ftcnkCyB)

![image](https://user-images.githubusercontent.com/32936089/92232859-2a9b6e80-eea7-11ea-9760-c6aeea677e0c.png)
