### PR TITLE
Bump path-parse from v1.0.6 to v1.0.7 in /example

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -5258,9 +5258,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "pbkdf2": {

--- a/example/package.json
+++ b/example/package.json
@@ -8,6 +8,7 @@
     "start:ci": "npm install && npm run start"
   },
   "dependencies": {
+    "path-parse": "^1.0.7",
     "react-app-polyfill": "^1.0.6"
   },
   "alias": {


### PR DESCRIPTION
Trello card : https://trello.com/c/J1UUco4V

We are currently reviewing the security issues raised in GitHub for this
repo. As part of this review, we need to update the `path-parse` package
within the example app repo to the latest version 1.0.7.

This resolves this [security vulnerability](https://github.com/futurelearn/markdown-editor/security/dependabot/example/package-lock.json/path-parse/open). 